### PR TITLE
Update dbopl from the official repository

### DIFF
--- a/dbopl.h
+++ b/dbopl.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2002-2020  The DOSBox Team
+ *  Copyright (C) 2002-2021  The DOSBox Team
  *
  *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -16,7 +16,6 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
  */
 
-
 /*
 	define Bits, Bitu, Bit32s, Bit32u, Bit16s, Bit16u, Bit8s, Bit8u here
 */
@@ -30,7 +29,6 @@ typedef uint16_t	Bit16u;
 typedef int16_t		Bit16s;
 typedef uint8_t		Bit8u;
 typedef int8_t		Bit8s;
-
 #define GCC_UNLIKELY(x) (x)
 #define GCC_LIKELY(x) (x)
 #define INLINE inline
@@ -214,7 +212,6 @@ struct Chip {
 	//This is used as the base counter for vibrato and tremolo
 	Bit32u lfoCounter;
 	Bit32u lfoAdd;
-	
 
 	Bit32u noiseCounter;
 	Bit32u noiseAdd;
@@ -242,6 +239,8 @@ struct Chip {
 	Bit8u waveFormMask;
 	//0 or -1 when enabled
 	Bit8s opl3Active;
+	//Running in opl3 mode
+	const bool opl3Mode;
 
 	//Return the maximum amount of samples before and LFO change
 	Bit32u ForwardLFO( Bit32u samples );
@@ -260,15 +259,18 @@ struct Chip {
 	void Generate( Bit32u samples );
 	void Setup( Bit32u r );
 
-	Chip();
+	Chip( bool opl3Mode );
 };
 
 struct Handler {
 	DBOPL::Chip chip;
 	Bit32u WriteAddr( Bit32u port, Bit8u val );
 	void WriteReg( Bit32u addr, Bit8u val );
-	void Generate( Bit32s *buffer, Bitu samples );
+	void Generate( Bit32s* chan, Bitu samples );
 	void Init( Bitu rate );
+
+	Handler(bool opl3Mode) : chip(opl3Mode) {
+	}
 };
 
 


### PR DESCRIPTION
qbix79: [4394]switch to WAVE_SH instead of LFO_SH (harekiet). Thanks for bringing it up psyraven.
qbix79: [4395]Another attempt
qbix79: [4406]It seems compilers prefer FALLTHROUGH else some start complaining.
qbix79: [4412]A new and hopeful better year
qbix79: [4468]Add proper opl3 handling of the waveform select to dbopl